### PR TITLE
Fix path change in library.js

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2,7 +2,7 @@ import ffi from 'ffi-napi';
 import ref from 'ref-napi';
 import path from 'path';
 
-const dylib = path.join(__dirname, '..', 'build', 'Release', 'obj.target', 'argon2');
+const dylib = path.join(__dirname, '..', 'build', 'Release', 'argon2');
 const lib = new ffi.Library(dylib, {
   argon2i_hash_encoded: ['int', ['uint32', 'uint32', 'uint32',    // t_cost, m_cost, p
                                  ref.refType('void'), 'size_t',   // password


### PR DESCRIPTION
Hi,

I don't know if it's related to macos or to dependency change, anyway, 
Argon-ffi cannot found argon2.dylib (Dynamic Linking Error) , this pull  fix that...

compilaton log:
...
SOLINK(target) Release/argon2.dylib

best regards,
Alexandre  